### PR TITLE
Add Windows PowerShell installer parallel to Bash scripts

### DIFF
--- a/config/settings.conf
+++ b/config/settings.conf
@@ -30,6 +30,9 @@ ZABBIX_STATIC_AGENT_URL="https://cdn.zabbix.com/zabbix/binaries/stable/7.0/7.0.2
 # Ramo do repositório Zabbix para RPM em RHEL (ex.: 7.0 → repo .../zabbix/7.0/rhel/...)
 ZABBIX_RPM_BRANCH="7.0"
 
+# MSI oficial do agente Zabbix para Windows (amd64, OpenSSL). Usado apenas pelo instalador PowerShell em windows/.
+ZABBIX_WINDOWS_MSI_URL="https://cdn.zabbix.com/zabbix/binaries/stable/7.0/7.0.25/zabbix_agent-7.0.25-windows-amd64-openssl.msi"
+
 #------------------------------------------------------------------------------
 # Configurações do Wazuh
 #------------------------------------------------------------------------------

--- a/windows/Install-Wazuh.ps1
+++ b/windows/Install-Wazuh.ps1
@@ -1,0 +1,94 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs Wazuh Agent on Windows from packages.wazuh.com MSI (settings.conf).
+.PARAMETER WazuhManager
+    Optional override for WAZUH_MANAGER.
+#>
+[CmdletBinding()]
+param(
+    [string]$WazuhManager
+)
+
+$ErrorActionPreference = 'Stop'
+$windowsRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $windowsRoot 'lib\Common.psm1') -Force
+
+$repo = Get-InstallerRepoRoot
+$settingsPath = Join-Path $repo 'config\settings.conf'
+$settings = Read-InstallerSettingsConf -Path $settingsPath
+
+$logDir = if ($settings['LOG_DIR']) { $settings['LOG_DIR'] } else { './logs' }
+Initialize-InstallerLogging -LogDirectory $logDir
+
+try {
+    Write-InstallerHeader 'Wazuh Agent installation'
+    Assert-InstallerAdministrator
+
+    if (Get-InstallerSettingsBool -Settings $settings -Key 'CHECK_INTERNET' -Default $true) {
+        if (-not (Test-InstallerInternetConnectivity)) {
+            Write-InstallerError 'Internet is required for this installation.'
+            exit 1
+        }
+    }
+
+    $ver = if ($settings['WAZUH_VERSION']) { $settings['WAZUH_VERSION'].Trim() } else { '4.14.0' }
+    $rev = if ($settings['WAZUH_REVISION']) { $settings['WAZUH_REVISION'].Trim() } else { '1' }
+    $manager = if ($WazuhManager) { $WazuhManager.Trim() } else { $settings['WAZUH_MANAGER'].Trim() }
+
+    if ([string]::IsNullOrWhiteSpace($manager)) {
+        Write-InstallerError 'WAZUH_MANAGER is empty in config/settings.conf.'
+        exit 1
+    }
+
+    $msiUrl = "https://packages.wazuh.com/4.x/windows/wazuh-agent-$ver-$rev.msi"
+    $msiLocal = Join-Path $env:TEMP ("wazuh-agent-$ver-$rev.msi")
+
+    Write-InstallerInfo "Downloading: $msiUrl"
+    Invoke-WebRequest -Uri $msiUrl -OutFile $msiLocal -UseBasicParsing
+
+    $msiArgs = @(
+        '/i', "`"$msiLocal`"",
+        '/qn', '/norestart',
+        "WAZUH_MANAGER=$manager"
+    )
+
+    $argLine = $msiArgs -join ' '
+    Write-InstallerInfo "Running msiexec $argLine"
+    Write-InstallerLogLine 'INFO' "msiexec $argLine"
+
+    $p = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        Write-InstallerError ("msiexec exited with code {0}." -f $p.ExitCode)
+        exit $p.ExitCode
+    }
+
+    $svc = Get-Service -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -match 'Wazuh' -or $_.DisplayName -match 'Wazuh'
+    } | Select-Object -First 1
+
+    if ($svc) {
+        Set-Service -Name $svc.Name -StartupType Automatic -ErrorAction SilentlyContinue
+        Start-Service -Name $svc.Name -ErrorAction Stop
+        Start-Sleep -Seconds 2
+        $svc2 = Get-Service -Name $svc.Name
+        if ($svc2.Status -ne 'Running') {
+            Write-InstallerWarning "Service $($svc.Name) status: $($svc2.Status)"
+        }
+        else {
+            Write-InstallerSuccess "Wazuh Agent service is running ($($svc.Name))."
+        }
+    }
+    else {
+        Write-InstallerWarning 'Wazuh Windows service not found; verify installation manually.'
+    }
+
+    Write-InstallerInfo 'Configuration is typically under "C:\Program Files (x86)\ossec-agent" or "C:\Program Files\ossec-agent".'
+
+    Write-InstallerSeparator
+    Write-InstallerSuccess 'Wazuh Agent installation finished.'
+    Write-InstallerInfo ("Log file: {0}" -f (Get-InstallerLogFile))
+}
+finally {
+    Write-InstallerLogEnd
+}

--- a/windows/Install-Zabbix.ps1
+++ b/windows/Install-Zabbix.ps1
@@ -1,0 +1,108 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs Zabbix Agent on Windows from the official MSI (settings.conf).
+.PARAMETER ZabbixServer
+    Optional override for Zabbix server/proxy (maps to SERVER / SERVERACTIVE).
+#>
+[CmdletBinding()]
+param(
+    [string]$ZabbixServer
+)
+
+$ErrorActionPreference = 'Stop'
+$windowsRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $windowsRoot 'lib\Common.psm1') -Force
+
+$repo = Get-InstallerRepoRoot
+$settingsPath = Join-Path $repo 'config\settings.conf'
+$settings = Read-InstallerSettingsConf -Path $settingsPath
+
+$logDir = if ($settings['LOG_DIR']) { $settings['LOG_DIR'] } else { './logs' }
+Initialize-InstallerLogging -LogDirectory $logDir
+
+try {
+    Write-InstallerHeader 'Zabbix Agent installation'
+    Assert-InstallerAdministrator
+
+    if (Get-InstallerSettingsBool -Settings $settings -Key 'CHECK_INTERNET' -Default $true) {
+        if (-not (Test-InstallerInternetConnectivity)) {
+            Write-InstallerError 'Internet is required for this installation.'
+            exit 1
+        }
+    }
+
+    if (-not [Environment]::Is64BitOperatingSystem) {
+        Write-InstallerError 'This MSI is for 64-bit Windows (amd64).'
+        exit 1
+    }
+
+    $msiUrl = if ($settings['ZABBIX_WINDOWS_MSI_URL']) {
+        $settings['ZABBIX_WINDOWS_MSI_URL'].Trim()
+    }
+    else {
+        'https://cdn.zabbix.com/zabbix/binaries/stable/7.0/7.0.25/zabbix_agent-7.0.25-windows-amd64-openssl.msi'
+    }
+
+    $server = if ($ZabbixServer) { $ZabbixServer.Trim() } else { $settings['ZABBIX_PROXY_SERVER'].Trim() }
+    if ([string]::IsNullOrWhiteSpace($server)) {
+        Write-InstallerError 'ZABBIX_PROXY_SERVER is empty in config/settings.conf.'
+        exit 1
+    }
+
+    $serverPort = if ($settings['ZABBIX_SERVER_PORT']) { $settings['ZABBIX_SERVER_PORT'].Trim() } else { '10051' }
+    $listenPort = if ($settings['ZABBIX_AGENT_PORT']) { [int]$settings['ZABBIX_AGENT_PORT'] } else { 10050 }
+    $hostname = $env:COMPUTERNAME
+    $serverActive = '{0}:{1}' -f $server, $serverPort
+
+    $msiLocal = Join-Path $env:TEMP ('zabbix_agent_windows_{0}.msi' -f (Get-Date -Format 'yyyyMMddHHmmss'))
+
+    Write-InstallerInfo "Downloading: $msiUrl"
+    Invoke-WebRequest -Uri $msiUrl -OutFile $msiLocal -UseBasicParsing
+
+    # Public properties per Zabbix Windows MSI documentation (Server, ServerActive, ListenPort, Hostname).
+    $msiArgs = @(
+        '/i', "`"$msiLocal`"",
+        '/qn', '/norestart',
+        "SERVER=$server",
+        "SERVERACTIVE=$serverActive",
+        "LISTENPORT=$listenPort",
+        "HOSTNAME=$hostname",
+        'HOSTMETADATA=Windows'
+    )
+
+    $argLine = $msiArgs -join ' '
+    Write-InstallerInfo "Running msiexec $argLine"
+    Write-InstallerLogLine 'INFO' "msiexec $argLine"
+
+    $p = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        Write-InstallerError ("msiexec exited with code {0}. See Windows Application log or run with /l*v for verbose MSI logging." -f $p.ExitCode)
+        exit $p.ExitCode
+    }
+
+    Add-InstallerFirewallTcpPort -Port $listenPort -DisplayName 'Zabbix Agent inbound'
+
+    $svc = Get-Service -ErrorAction SilentlyContinue | Where-Object { $_.Name -like 'Zabbix*' -or $_.DisplayName -like '*Zabbix*' } | Select-Object -First 1
+    if ($svc) {
+        Set-Service -Name $svc.Name -StartupType Automatic -ErrorAction SilentlyContinue
+        Restart-Service -Name $svc.Name -Force -ErrorAction Stop
+        Start-Sleep -Seconds 2
+        $svc2 = Get-Service -Name $svc.Name
+        if ($svc2.Status -ne 'Running') {
+            Write-InstallerError "Service $($svc.Name) is not running (status: $($svc2.Status))."
+            exit 1
+        }
+        Write-InstallerSuccess "Zabbix Agent service is running ($($svc.Name))."
+    }
+    else {
+        Write-InstallerWarning 'Zabbix Windows service not found by name pattern; verify installation manually.'
+    }
+
+    Write-InstallerSeparator
+    Write-InstallerSuccess 'Zabbix Agent installation finished.'
+    Write-InstallerInfo ("Log file: {0}" -f (Get-InstallerLogFile))
+}
+finally {
+    Write-InstallerLogEnd
+}

--- a/windows/Installer.ps1
+++ b/windows/Installer.ps1
@@ -1,0 +1,290 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Interactive Windows installer menu (parallel to installer.sh).
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\windows\Installer.ps1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Continue'
+$windowsRoot = $PSScriptRoot
+Import-Module (Join-Path $windowsRoot 'lib\Common.psm1') -Force
+
+$repo = Get-InstallerRepoRoot
+$settingsPath = Join-Path $repo 'config\settings.conf'
+$settings = Read-InstallerSettingsConf -Path $settingsPath
+
+$logDir = if ($settings['LOG_DIR']) { $settings['LOG_DIR'] } else { './logs' }
+Initialize-InstallerLogging -LogDirectory $logDir
+
+function Show-InstallerBanner {
+    Clear-Host
+    Write-Host ''
+    Write-Host "`e[36m"
+    @'
++===============================================================+
+|                                                               |
+|     Windows Application Installer / Configuration Menu        |
+|     (PowerShell port — Zabbix, Wazuh, Hostname, Domain)       |
+|                                                               |
++===============================================================+
+'@
+    Write-Host "`e[0m"
+}
+
+function Get-InstallerPrimaryIPv4 {
+    try {
+        $candidates = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+            Where-Object { $_.IPAddress -notlike '127.*' -and $_.IPAddress -notlike '169.254.*' }
+        if (-not $candidates) { return '' }
+        $sorted = $candidates | Sort-Object { if ($_.InterfaceMetric) { $_.InterfaceMetric } else { 999 } }
+        return ($sorted | Select-Object -First 1 -ExpandProperty IPAddress)
+    }
+    catch {
+        return ''
+    }
+}
+
+function Show-InstallerSystemInfo {
+    $os = ''
+    try {
+        $os = (Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue).Caption
+    }
+    catch { }
+
+    $ip = Get-InstallerPrimaryIPv4
+    Write-Host ("`e[37mOS:`e[0m {0}" -f $(if ($os) { $os } else { 'Windows' }))
+    Write-Host ("`e[37mComputer:`e[0m {0}" -f $env:COMPUTERNAME)
+    Write-Host ("`e[37mIPv4:`e[0m {0}" -f $(if ($ip) { $ip } else { '(unknown)' }))
+    Write-Host ''
+}
+
+function Show-InstallerMainMenu {
+    Write-Host "`e[35m+=================================================+`e[0m"
+    Write-Host "`e[35m|              MAIN MENU                          |`e[0m"
+    Write-Host "`e[35m+=================================================+`e[0m"
+    Write-Host ''
+    Write-Host "  `e[32m1`e[0m) `e[36mInstall Zabbix Agent`e[0m"
+    Write-Host '     Download MSI and install/configure the agent'
+    Write-Host ''
+    Write-Host "  `e[32m2`e[0m) `e[36mSet computer name (hostname)`e[0m"
+    Write-Host '     Rename the computer (reboot required)'
+    Write-Host ''
+    Write-Host "  `e[32m3`e[0m) `e[36mInstall Wazuh Agent`e[0m"
+    Write-Host '     Download MSI and register with Wazuh manager'
+    Write-Host ''
+    Write-Host "  `e[32m4`e[0m) `e[36mSophos`e[0m"
+    Write-Host '     Not automated on Windows in this repo (use Sophos Central / Windows installer)'
+    Write-Host ''
+    Write-Host "  `e[32m5`e[0m) `e[36mJoin Active Directory domain`e[0m"
+    Write-Host '     Online domain join (not Linux SSSD/realm)'
+    Write-Host ''
+    Write-Host "  `e[32m6`e[0m) `e[36mRun full sequence`e[0m"
+    Write-Host '     Hostname, Zabbix, Wazuh, optional Sophos note, optional domain join'
+    Write-Host ''
+    Write-Host "  `e[33m7`e[0m) `e[36mOpen settings file`e[0m"
+    Write-Host "     Edit config\settings.conf"
+    Write-Host ''
+    Write-Host "  `e[33m8`e[0m) `e[36mView logs`e[0m"
+    Write-Host '     List recent installer logs'
+    Write-Host ''
+    Write-Host "  `e[31m0`e[0m) `e[31mExit`e[0m"
+    Write-Host ''
+    Write-Host "`e[34m---------------------------------------------------`e[0m"
+}
+
+function Invoke-InstallerChildScript {
+    param([string]$RelativePath)
+    $path = Join-Path $windowsRoot $RelativePath
+    if (-not (Test-Path -LiteralPath $path)) {
+        Write-InstallerError "Script not found: $path"
+        return 1
+    }
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $path
+    return $LASTEXITCODE
+}
+
+function Edit-InstallerSettingsFile {
+    Write-InstallerHeader 'Settings'
+    if (-not (Test-Path -LiteralPath $settingsPath)) {
+        Write-InstallerError "Configuration file not found: $settingsPath"
+        Wait-InstallerKey
+        return
+    }
+    Write-InstallerInfo 'Opening settings in your default editor...'
+    Write-InstallerWarning 'Edit carefully; invalid values can break installs.'
+    try {
+        if (Get-Command notepad.exe -ErrorAction SilentlyContinue) {
+            Start-Process -FilePath 'notepad.exe' -ArgumentList "`"$settingsPath`"" -Wait
+        }
+        else {
+            Invoke-Item -LiteralPath $settingsPath
+        }
+        Write-InstallerSuccess 'Editor closed.'
+    }
+    catch {
+        Write-InstallerError $_.Exception.Message
+    }
+    Wait-InstallerKey
+}
+
+function Show-InstallerLogs {
+    Write-InstallerHeader 'Installation logs'
+    $logsDir = Join-Path $repo 'logs'
+    if (-not (Test-Path -LiteralPath $logsDir)) {
+        Write-InstallerError "Log directory not found: $logsDir"
+        Wait-InstallerKey
+        return
+    }
+
+    $logs = Get-ChildItem -LiteralPath $logsDir -Filter '*.log' -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending
+
+    if (-not $logs) {
+        Write-InstallerInfo 'No log files found.'
+        Wait-InstallerKey
+        return
+    }
+
+    Write-InstallerInfo 'Available logs:'
+    Write-Host ''
+    $i = 1
+    foreach ($f in $logs) {
+        Write-Host ("  {0}) {1} ({2} bytes) - {3}" -f $i, $f.Name, $f.Length, $f.LastWriteTime)
+        $i++
+    }
+    Write-Host ''
+    Write-Host '  0) Back'
+    Write-Host ''
+    $choice = Read-Host 'Select a log number to view (0 = back)'
+    if ($choice -eq '0' -or [string]::IsNullOrWhiteSpace($choice)) { return }
+
+    $idx = 0
+    if ([int]::TryParse($choice, [ref]$idx) -and $idx -ge 1 -and $idx -le $logs.Count) {
+        $sel = $logs[$idx - 1]
+        Write-InstallerInfo "Showing: $($sel.Name)"
+        Write-Host ''
+        Get-Content -LiteralPath $sel.FullName -Tail 200 | ForEach-Object { Write-Host $_ }
+    }
+    else {
+        Write-InstallerError 'Invalid selection.'
+    }
+    Wait-InstallerKey
+}
+
+function Show-InstallerSophosStub {
+    Write-InstallerHeader 'Sophos'
+    Write-InstallerInfo 'Sophos for Windows is not installed by this repository.'
+    Write-InstallerInfo 'Use Sophos Central or the official Windows installer from Sophos.'
+    Write-InstallerLogLine 'INFO' 'Sophos menu: stub only'
+    Wait-InstallerKey
+}
+
+function Invoke-InstallerFullSequence {
+    Write-InstallerHeader 'Full installation sequence'
+    Write-InstallerWarning 'This will run, in order:'
+    Write-Host '  1) Set computer name (you can cancel inside the script)'
+    Write-Host '  2) Install Zabbix Agent'
+    Write-Host '  3) Install Wazuh Agent'
+    Write-Host '  4) Sophos — skipped (see menu item 4)'
+    Write-Host '  5) Join domain — optional'
+    Write-Host ''
+    if (-not (Read-InstallerConfirm -PromptText 'Continue with full sequence?' -DefaultYes $false)) {
+        Write-InstallerInfo 'Cancelled.'
+        Wait-InstallerKey
+        return
+    }
+
+    $failed = 0
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Step 1/5: Computer name'
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $windowsRoot 'Set-Hostname.ps1')
+    if ($LASTEXITCODE -ne 0) { $failed++ }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Step 2/5: Zabbix Agent'
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $windowsRoot 'Install-Zabbix.ps1')
+    if ($LASTEXITCODE -ne 0) { $failed++ }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Step 3/5: Wazuh Agent'
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $windowsRoot 'Install-Wazuh.ps1')
+    if ($LASTEXITCODE -ne 0) { $failed++ }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Step 4/5: Sophos — skipped by design on Windows'
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Step 5/5: Domain join'
+    if (Read-InstallerConfirm -PromptText 'Join this computer to a domain now?' -DefaultYes $false) {
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $windowsRoot 'Join-Domain.ps1')
+        if ($LASTEXITCODE -ne 0) { $failed++ }
+    }
+    else {
+        Write-InstallerInfo 'Domain join skipped.'
+    }
+
+    Write-InstallerSeparator
+    Write-InstallerHeader 'Summary'
+    if ($failed -eq 0) {
+        Write-InstallerSuccess 'Full sequence completed without reported script failures.'
+    }
+    else {
+        Write-InstallerWarning "$failed step(s) returned a non-zero exit code. Review logs in logs\"
+    }
+    Write-InstallerInfo ("Session log: {0}" -f (Get-InstallerLogFile))
+    Wait-InstallerKey
+}
+
+Assert-InstallerAdministrator
+
+try {
+    while ($true) {
+        Show-InstallerBanner
+        Show-InstallerSystemInfo
+        Show-InstallerMainMenu
+        $choice = Read-Host "`e[32mEnter choice`e[0m"
+
+        switch ($choice) {
+            '1' {
+                Write-InstallerHeader 'Zabbix Agent'
+                Invoke-InstallerChildScript 'Install-Zabbix.ps1' | Out-Null
+                Wait-InstallerKey
+            }
+            '2' {
+                Write-InstallerHeader 'Computer name'
+                Invoke-InstallerChildScript 'Set-Hostname.ps1' | Out-Null
+                Wait-InstallerKey
+            }
+            '3' {
+                Write-InstallerHeader 'Wazuh Agent'
+                Invoke-InstallerChildScript 'Install-Wazuh.ps1' | Out-Null
+                Wait-InstallerKey
+            }
+            '4' { Show-InstallerSophosStub }
+            '5' {
+                Write-InstallerHeader 'Domain join'
+                Invoke-InstallerChildScript 'Join-Domain.ps1' | Out-Null
+                Wait-InstallerKey
+            }
+            '6' { Invoke-InstallerFullSequence }
+            '7' { Edit-InstallerSettingsFile }
+            '8' { Show-InstallerLogs }
+            '0' {
+                Write-InstallerInfo 'Exiting.'
+                Write-InstallerLogEnd
+                exit 0
+            }
+            Default {
+                Write-InstallerError "Invalid option: $choice"
+                Wait-InstallerKey
+            }
+        }
+    }
+}
+finally {
+    Write-InstallerLogEnd
+}

--- a/windows/Join-Domain.ps1
+++ b/windows/Join-Domain.ps1
@@ -1,0 +1,124 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Joins the computer to an Active Directory domain (Windows equivalent of domain registration).
+.NOTES
+    This is not the same as Linux realm/SSSD. Access control is governed by AD/GPO and local groups.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$windowsRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $windowsRoot 'lib\Common.psm1') -Force
+
+$repo = Get-InstallerRepoRoot
+$settingsPath = Join-Path $repo 'config\settings.conf'
+$settings = Read-InstallerSettingsConf -Path $settingsPath
+
+$logDir = if ($settings['LOG_DIR']) { $settings['LOG_DIR'] } else { './logs' }
+Initialize-InstallerLogging -LogDirectory $logDir
+
+try {
+    Write-InstallerHeader 'Domain join'
+    Assert-InstallerAdministrator
+
+    $defaultDomain = if ($settings['DEFAULT_DOMAIN']) { $settings['DEFAULT_DOMAIN'].Trim() } else { '' }
+    $defaultUser = if ($settings['DEFAULT_ADMIN_USER']) { $settings['DEFAULT_ADMIN_USER'].Trim() } else { '' }
+    $defaultGroup = if ($settings['DEFAULT_ADMIN_GROUP']) { $settings['DEFAULT_ADMIN_GROUP'].Trim() } else { '' }
+    $presetComputerName = if ($settings['DOMAIN_COMPUTER_NAME']) { $settings['DOMAIN_COMPUTER_NAME'].Trim() } else { '' }
+
+    $domain = Invoke-InstallerUserPrompt -PromptText 'DNS domain name (e.g. corp.example.com)' -DefaultValue $defaultDomain
+    if ([string]::IsNullOrWhiteSpace($domain)) {
+        Write-InstallerError 'Domain name is required.'
+        exit 1
+    }
+
+    Write-InstallerInfo 'You will be prompted for domain credentials (user with rights to join the domain).'
+    $user = Invoke-InstallerUserPrompt -PromptText 'User name (DOMAIN\user or user@domain.com)' -DefaultValue $defaultUser
+    if ([string]::IsNullOrWhiteSpace($user)) {
+        Write-InstallerError 'User name is required.'
+        exit 1
+    }
+
+    $plain = Read-InstallerPasswordPlain -PromptText 'Password'
+    if ([string]::IsNullOrWhiteSpace($plain)) {
+        Write-InstallerError 'Password cannot be empty.'
+        exit 1
+    }
+
+    $secure = ConvertTo-SecureString -String $plain -AsPlainText -Force
+    $cred = New-Object System.Management.Automation.PSCredential ($user, $secure)
+    $plain = $null
+
+    $newComputerName = $presetComputerName
+    if ([string]::IsNullOrWhiteSpace($newComputerName)) {
+        $useNew = Read-InstallerConfirm -PromptText 'Rename computer before joining? (max 15 chars NetBIOS)' -DefaultYes $false
+        if ($useNew) {
+            $newComputerName = Invoke-InstallerUserPrompt -PromptText 'New computer name (leave empty to keep current)'
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($newComputerName)) {
+        if ($newComputerName.Length -gt 15) {
+            Write-InstallerError 'Computer NetBIOS name must be 15 characters or fewer.'
+            exit 1
+        }
+    }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Choose post-join local group membership for a domain group (optional).'
+    Write-InstallerInfo '1) Do not add domain groups to local groups (use GPO/AD only)'
+    Write-InstallerInfo '2) Add a domain group to local Administrators'
+    Write-InstallerInfo '3) Add a domain group to Remote Desktop Users'
+    $mode = Invoke-InstallerUserPrompt -PromptText 'Choice [1-3]' -DefaultValue '1'
+
+    $groupToAdd = $null
+    $localTarget = $null
+    switch ($mode) {
+        '2' {
+            $localTarget = 'Administrators'
+            $groupToAdd = Invoke-InstallerUserPrompt -PromptText 'Domain group (e.g. CONTOSO\Server-Admins)' -DefaultValue $defaultGroup
+        }
+        '3' {
+            $localTarget = 'Remote Desktop Users'
+            $groupToAdd = Invoke-InstallerUserPrompt -PromptText 'Domain group (e.g. CONTOSO\RDS-Users)' -DefaultValue $defaultGroup
+        }
+        Default { }
+    }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo "Joining domain '$domain'..."
+
+    $joinParams = @{
+        DomainName   = $domain
+        Credential   = $cred
+        Force        = $true
+        ErrorAction  = 'Stop'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($newComputerName)) {
+        $joinParams['NewName'] = $newComputerName
+    }
+
+    Add-Computer @joinParams
+    Write-InstallerSuccess 'Domain join completed.'
+    Write-InstallerWarning 'A reboot is usually required to finish the domain join.'
+
+    if ($localTarget -and -not [string]::IsNullOrWhiteSpace($groupToAdd)) {
+        try {
+            Add-LocalGroupMember -Group $localTarget -Member $groupToAdd -ErrorAction Stop
+            Write-InstallerSuccess "Added '$groupToAdd' to local '$localTarget'."
+        }
+        catch {
+            Write-InstallerWarning "Could not add group to '$localTarget': $($_.Exception.Message)"
+        }
+    }
+    elseif ($localTarget) {
+        Write-InstallerWarning 'No domain group entered; skipping local group update.'
+    }
+
+    Write-InstallerInfo ("Log file: {0}" -f (Get-InstallerLogFile))
+}
+finally {
+    Write-InstallerLogEnd
+}

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,56 @@
+# Windows PowerShell installer
+
+This folder mirrors the Linux Bash installer in the repository root. It installs **Zabbix Agent** and **Wazuh Agent** from official HTTPS MSIs, can **rename the computer**, and can **join Active Directory** using the same `config/settings.conf` values as the Linux scripts.
+
+## Requirements
+
+- Windows 10 / 11 or Windows Server (64-bit) for the default Zabbix MSI (amd64).
+- **PowerShell 5.1 or later**, run **as Administrator**.
+- Outbound **HTTPS** access to `cdn.zabbix.com` and `packages.wazuh.com`.
+- For domain join: DNS resolution of the domain, connectivity to domain controllers, and an account that may join computers to the domain.
+
+## Usage
+
+From the repository root:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+cd <path-to-repo>
+.\windows\Installer.ps1
+```
+
+Or run individual scripts:
+
+```powershell
+.\windows\Install-Zabbix.ps1
+.\windows\Install-Wazuh.ps1
+.\windows\Set-Hostname.ps1
+.\windows\Join-Domain.ps1
+```
+
+Optional overrides (same idea as passing `$1` on Linux):
+
+```powershell
+.\windows\Install-Zabbix.ps1 -ZabbixServer 'zabbix.example.com'
+.\windows\Install-Wazuh.ps1 -WazuhManager 'manager.example.com'
+```
+
+## Configuration
+
+Edit `config/settings.conf` in the repo root. Windows-specific defaults include:
+
+- `ZABBIX_WINDOWS_MSI_URL` — official Zabbix Windows MSI (OpenSSL amd64).
+- `ZABBIX_PROXY_SERVER`, `ZABBIX_SERVER_PORT`, `ZABBIX_AGENT_PORT` — passed into the Zabbix MSI as `SERVER`, `SERVERACTIVE`, and `LISTENPORT`.
+- `WAZUH_VERSION`, `WAZUH_REVISION`, `WAZUH_MANAGER` — used to build the Wazuh MSI URL and `WAZUH_MANAGER` for `msiexec`.
+
+## Sophos
+
+There is **no** bundled Sophos Windows installer here. Use Sophos Central or Sophos-supplied Windows packages for your tenant.
+
+## Domain join vs Linux `register_domain.sh`
+
+Linux domain registration in this repo uses **realm/SSSD** (Ubuntu-oriented). On Windows, **Join-Domain.ps1** uses **`Add-Computer`** for a standard AD join. Fine-grained login and remote access rules are normally handled by **Group Policy** and **AD group membership**, not by SSSD options.
+
+## Logs
+
+Installer scripts append to timestamped files under the repository `logs/` directory (same `LOG_DIR` convention as Linux).

--- a/windows/Set-Hostname.ps1
+++ b/windows/Set-Hostname.ps1
@@ -1,0 +1,54 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Renames the computer (Windows equivalent of hostname.sh).
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$windowsRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $windowsRoot 'lib\Common.psm1') -Force
+
+$repo = Get-InstallerRepoRoot
+$settingsPath = Join-Path $repo 'config\settings.conf'
+$settings = Read-InstallerSettingsConf -Path $settingsPath
+
+$logDir = if ($settings['LOG_DIR']) { $settings['LOG_DIR'] } else { './logs' }
+Initialize-InstallerLogging -LogDirectory $logDir
+
+try {
+    Write-InstallerHeader 'Hostname configuration'
+    Assert-InstallerAdministrator
+
+    $current = $env:COMPUTERNAME
+    Write-InstallerInfo "Current computer name: $current"
+    Write-InstallerSeparator
+
+    $newName = Invoke-InstallerUserPrompt -PromptText 'Enter new computer name (hostname)'
+    if ([string]::IsNullOrWhiteSpace($newName)) {
+        Write-InstallerError 'Name cannot be empty.'
+        exit 1
+    }
+
+    if ($newName -notmatch '^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$') {
+        Write-InstallerError 'Invalid name. Use letters, numbers, and hyphens; must start and end with a letter or number.'
+        exit 1
+    }
+
+    Write-InstallerWarning "Rename computer from '$current' to '$newName'"
+    if (-not (Read-InstallerConfirm -PromptText 'Confirm rename?' -DefaultYes $false)) {
+        Write-InstallerInfo 'Cancelled.'
+        exit 0
+    }
+
+    Write-InstallerSeparator
+    Write-InstallerInfo 'Renaming computer...'
+    Rename-Computer -NewName $newName -Force
+    Write-InstallerSuccess "Computer will use name '$newName' after reboot."
+    Write-InstallerWarning 'Reboot the system for the name change to take full effect.'
+    Write-InstallerInfo ("Log file: {0}" -f (Get-InstallerLogFile))
+}
+finally {
+    Write-InstallerLogEnd
+}

--- a/windows/lib/Common.psm1
+++ b/windows/lib/Common.psm1
@@ -1,0 +1,296 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Shared helpers for the Windows PowerShell installer (parallel to lib/common.sh).
+#>
+
+$script:InstallerLogFile = $null
+$script:InstallerLogDir = $null
+
+function Get-InstallerRepoRoot {
+    <#
+    PSScriptRoot for this module is <repo>/windows/lib — repo root is two levels up.
+    #>
+    $windowsDir = Split-Path -Parent $PSScriptRoot
+    return (Split-Path -Parent $windowsDir)
+}
+
+function Get-InstallerWindowsRoot {
+    Split-Path -Parent $PSScriptRoot
+}
+
+function Initialize-InstallerLogging {
+    [CmdletBinding()]
+    param(
+        [string]$LogDirectory
+    )
+
+    $repo = Get-InstallerRepoRoot
+    if (-not $LogDirectory) {
+        $LogDirectory = Join-Path $repo 'logs'
+    }
+    elseif ($LogDirectory -match '^\./') {
+        $LogDirectory = Join-Path $repo ($LogDirectory.TrimStart('.', '/').TrimStart('\'))
+    }
+    elseif (-not [System.IO.Path]::IsPathRooted($LogDirectory)) {
+        $LogDirectory = Join-Path $repo $LogDirectory
+    }
+
+    if (-not (Test-Path -LiteralPath $LogDirectory)) {
+        New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
+    }
+
+    $script:InstallerLogDir = $LogDirectory
+    $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $script:InstallerLogFile = Join-Path $LogDirectory "installer_$stamp.log"
+    New-Item -ItemType File -Path $script:InstallerLogFile -Force | Out-Null
+
+    Write-InstallerLogLine 'INFO' "Start: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+}
+
+function Get-InstallerLogFile {
+    $script:InstallerLogFile
+}
+
+function Write-InstallerLogLine {
+    param(
+        [Parameter(Mandatory)][string]$Level,
+        [Parameter(Mandatory)][string]$Message
+    )
+    if (-not $script:InstallerLogFile) { return }
+    $line = "[{0}] [{1}] {2}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Level, $Message
+    Add-Content -LiteralPath $script:InstallerLogFile -Value $line -Encoding UTF8
+}
+
+function Write-InstallerSuccess {
+    param([string]$Message)
+    Write-Host ("`e[32m✓ {0}`e[0m" -f $Message)
+    Write-InstallerLogLine 'SUCCESS' $Message
+}
+
+function Write-InstallerError {
+    param([string]$Message)
+    Write-Host ("`e[31m✗ {0}`e[0m" -f $Message)
+    Write-InstallerLogLine 'ERROR' $Message
+}
+
+function Write-InstallerWarning {
+    param([string]$Message)
+    Write-Host ("`e[33m⚠ {0}`e[0m" -f $Message)
+    Write-InstallerLogLine 'WARNING' $Message
+}
+
+function Write-InstallerInfo {
+    param([string]$Message)
+    Write-Host ("`e[36mℹ {0}`e[0m" -f $Message)
+    Write-InstallerLogLine 'INFO' $Message
+}
+
+function Write-InstallerHeader {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host ("`e[35m================================`e[0m")
+    Write-Host ("`e[35m  {0}`e[0m" -f $Title)
+    Write-Host ("`e[35m================================`e[0m")
+    Write-Host ""
+    Write-InstallerLogLine 'INFO' "HEADER: $Title"
+}
+
+function Write-InstallerSeparator {
+    Write-Host ("`e[34m────────────────────────────────`e[0m")
+}
+
+function Test-InstallerAdministrator {
+    $principal = [Security.Principal.WindowsPrincipal]::new(
+        [Security.Principal.WindowsIdentity]::GetCurrent()
+    )
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Assert-InstallerAdministrator {
+    if (-not (Test-InstallerAdministrator)) {
+        Write-InstallerError 'Run PowerShell as Administrator.'
+        Write-InstallerLogLine 'ERROR' 'Elevation required'
+        exit 1
+    }
+    Write-InstallerLogLine 'INFO' 'Administrator check: OK'
+}
+
+function Test-InstallerInternetConnectivity {
+    try {
+        Write-InstallerInfo 'Checking internet connectivity...'
+        $ok = Test-Connection -ComputerName '8.8.8.8' -Count 1 -Quiet -ErrorAction SilentlyContinue
+        if ($ok) {
+            Write-InstallerSuccess 'Internet connectivity: OK'
+            Write-InstallerLogLine 'SUCCESS' 'Internet check passed'
+            return $true
+        }
+    }
+    catch { }
+    Write-InstallerError 'No internet connectivity (ping to 8.8.8.8 failed).'
+    Write-InstallerLogLine 'ERROR' 'Internet check failed'
+    return $false
+}
+
+function Get-InstallerSettingsPath {
+    Join-Path (Get-InstallerRepoRoot) 'config\settings.conf'
+}
+
+function Read-InstallerSettingsConf {
+    [CmdletBinding()]
+    param(
+        [string]$Path = (Get-InstallerSettingsPath)
+    )
+
+    $result = @{}
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $result
+    }
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path -Encoding UTF8) {
+        $line = $rawLine.Trim()
+        if (-not $line -or $line.StartsWith('#')) { continue }
+
+        if ($line -match '^\s*([A-Za-z0-9_]+)\s*=\s*(.+)\s*$') {
+            $key = $Matches[1]
+            $val = $Matches[2].Trim()
+
+            if (($val.StartsWith('"') -and $val.EndsWith('"')) -or ($val.StartsWith("'") -and $val.EndsWith("'"))) {
+                $val = $val.Substring(1, $val.Length - 2)
+            }
+            $result[$key] = $val
+        }
+    }
+
+    return $result
+}
+
+function Get-InstallerSettingsBool {
+    param(
+        [hashtable]$Settings,
+        [string]$Key,
+        [bool]$Default = $true
+    )
+    if (-not $Settings.ContainsKey($Key)) { return $Default }
+    $v = $Settings[$Key].ToString().Trim().ToLowerInvariant()
+    return @('1', 'true', 'yes', 'y', 'on') -contains $v
+}
+
+function Invoke-InstallerUserPrompt {
+    param(
+        [string]$PromptText,
+        [string]$DefaultValue
+    )
+    if ($DefaultValue) {
+        $read = Read-Host ("{0} [{1}]" -f $PromptText, $DefaultValue)
+        if ([string]::IsNullOrWhiteSpace($read)) { return $DefaultValue }
+        return $read
+    }
+    return Read-Host $PromptText
+}
+
+function Read-InstallerConfirm {
+    param(
+        [string]$PromptText,
+        [bool]$DefaultYes = $false
+    )
+    $suffix = if ($DefaultYes) { '[Y/n]' } else { '[y/N]' }
+    $resp = Read-Host ("{0} {1}" -f $PromptText, $suffix)
+    if ([string]::IsNullOrWhiteSpace($resp)) {
+        return $DefaultYes
+    }
+    return $resp -match '^(y|yes|s|sim)$'
+}
+
+function Read-InstallerPasswordPlain {
+    param([string]$PromptText = 'Password')
+    $sec = Read-Host $PromptText -AsSecureString
+    $ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) | Out-Null
+    }
+}
+
+function Wait-InstallerKey {
+    Write-Host ""
+    Write-Host "`e[33mPress Enter to continue...`e[0m"
+    Read-Host | Out-Null
+}
+
+function Test-InstallerIpAddress {
+    param([string]$Ip)
+    if ([string]::IsNullOrWhiteSpace($Ip)) { return $false }
+    return [bool]($Ip -as [System.Net.IPAddress])
+}
+
+function Add-InstallerFirewallTcpPort {
+    param(
+        [int]$Port,
+        [string]$DisplayName
+    )
+
+    try {
+        $profiles = Get-NetFirewallProfile -ErrorAction SilentlyContinue |
+            Where-Object { $_.Enabled -eq 'True' }
+        if (-not $profiles) {
+            Write-InstallerInfo 'No enabled firewall profiles detected; skipping firewall rule.'
+            return
+        }
+
+        $existing = Get-NetFirewallRule -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -eq $DisplayName }
+        if ($existing) {
+            Write-InstallerInfo "Firewall rule already exists: $DisplayName"
+            return
+        }
+
+        New-NetFirewallRule -DisplayName $DisplayName -Direction Inbound -Action Allow -Protocol TCP -LocalPort $Port -ErrorAction Stop | Out-Null
+        Write-InstallerSuccess "Firewall: inbound TCP $Port ($DisplayName)"
+        Write-InstallerLogLine 'SUCCESS' "Firewall rule added: $DisplayName port $Port"
+    }
+    catch {
+        Write-InstallerWarning "Could not add firewall rule: $($_.Exception.Message)"
+        Write-InstallerLogLine 'WARNING' $_.Exception.Message
+    }
+}
+
+function Stop-InstallerTranscriptIfAny {
+    try { Stop-Transcript | Out-Null } catch { }
+}
+
+function Write-InstallerLogEnd {
+    if ($script:InstallerLogFile) {
+        Write-InstallerLogLine 'INFO' ("End: {0}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'))
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-InstallerRepoRoot',
+    'Get-InstallerWindowsRoot',
+    'Initialize-InstallerLogging',
+    'Get-InstallerLogFile',
+    'Write-InstallerSuccess',
+    'Write-InstallerError',
+    'Write-InstallerWarning',
+    'Write-InstallerInfo',
+    'Write-InstallerHeader',
+    'Write-InstallerSeparator',
+    'Write-InstallerLogLine',
+    'Test-InstallerAdministrator',
+    'Assert-InstallerAdministrator',
+    'Test-InstallerInternetConnectivity',
+    'Get-InstallerSettingsPath',
+    'Read-InstallerSettingsConf',
+    'Get-InstallerSettingsBool',
+    'Invoke-InstallerUserPrompt',
+    'Read-InstallerConfirm',
+    'Read-InstallerPasswordPlain',
+    'Wait-InstallerKey',
+    'Test-InstallerIpAddress',
+    'Add-InstallerFirewallTcpPort',
+    'Stop-InstallerTranscriptIfAny',
+    'Write-InstallerLogEnd'
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a **Windows PowerShell** sidecar under `windows/` so operators can run the same style of workflow as `installer.sh` on Windows Workstation or Server: **Zabbix Agent**, **Wazuh Agent**, **computer rename**, **Active Directory join**, plus **settings** and **log viewing**.

## What is included

- `windows/lib/Common.psm1` — logging, `config/settings.conf` parsing, elevation check, prompts, optional inbound firewall rule helper.
- `windows/Installer.ps1` — interactive menu aligned with the Linux installer (Sophos is a **stub**; no Windows Sophos payload in-repo).
- `windows/Install-Zabbix.ps1` — downloads the official **Zabbix 7.0.25** OpenSSL amd64 MSI (URL overridable via new `ZABBIX_WINDOWS_MSI_URL` in `config/settings.conf`), runs `msiexec` with `SERVER`, `SERVERACTIVE`, `LISTENPORT`, `HOSTNAME`, enables the service, and opens the listen port when Windows Firewall profiles are enabled.
- `windows/Install-Wazuh.ps1` — builds `https://packages.wazuh.com/4.x/windows/wazuh-agent-{VERSION}-{REV}.msi` from existing keys, installs with `WAZUH_MANAGER`, starts the Wazuh Windows service when found.
- `windows/Set-Hostname.ps1` — `Rename-Computer` with the same hostname validation pattern as `hostname.sh`.
- `windows/Join-Domain.ps1` — online `Add-Computer` domain join (not SSSD/realm); optional add of a domain group to local **Administrators** or **Remote Desktop Users**.
- `windows/README.md` — prerequisites (admin, HTTPS), usage, and domain-join vs Linux notes.

## Configuration

`config/settings.conf` gains **`ZABBIX_WINDOWS_MSI_URL`** (default points at the pinned OpenSSL MSI). Linux Bash scripts ignore unknown keys when sourced.

## Testing

Not run in this Linux CI environment. Please validate on a Windows VM: elevated PowerShell, outbound HTTPS, then menu options 1–3 and optionally 5.

## Limitations

- **Sophos** is intentionally not automated on Windows here.
- **Domain join** is standard Windows AD join; it does not replicate Ubuntu `realm`/SSSD/PAM behavior from `register_domain.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df5d5edf-b478-4770-bae1-17276298c8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df5d5edf-b478-4770-bae1-17276298c8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

